### PR TITLE
Update to newest version of dekit-core

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   },
   "appID": "7ba6726c608a43fd8b607d27841e2774",
   "dependencies": {
-    "devkit-core": "https://github.com/gameclosure/devkit-core#v3.0.2"
+    "devkit-core": "https://github.com/gameclosure/devkit-core#v4.5.0"
   },
   "icon": "resources/icons/icon512.png",
   "ios": {


### PR DESCRIPTION
There is an [issue](https://github.com/gameclosure/devkit-core/issues/38) with version 3.0.2 in which running `devkit install` fails due to jspio being declared as both a git submodule and an npm dependency.

This is the most current version of devkit-core and has been tested to work locally.